### PR TITLE
Asciidoctor jbosstools module build

### DIFF
--- a/features/build.properties
+++ b/features/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/features/org.jboss.tools.asciidoctor.feature/.project
+++ b/features/org.jboss.tools.asciidoctor.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.jboss.tools.asciidoctor.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.jboss.tools.asciidoctor.feature/build.properties
+++ b/features/org.jboss.tools.asciidoctor.feature/build.properties
@@ -1,0 +1,3 @@
+bin.includes = feature.xml,\
+               feature.properties,\
+               license.html

--- a/features/org.jboss.tools.asciidoctor.feature/feature.properties
+++ b/features/org.jboss.tools.asciidoctor.feature/feature.properties
@@ -1,0 +1,53 @@
+###############################################################################
+# Copyright (c) 2010-2012 Red Hat, Inc. and others.
+# All rights reserved. This program and the accompanying materials 
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# 
+# Contributors:
+#     JBoss by Red Hat - Initial implementation.
+##############################################################################
+# feature.properties
+# contains externalized strings for feature.xml
+# "%foo" in feature.xml corresponds to the key "foo" in this file
+# java.io.Properties file (ISO 8859-1 with "\" escapes)
+# This file should be translated.
+
+# "featureName" property - name of the feature
+featureName=JBoss Tools Asciidoctor Preview
+
+# "providerName" property - name of the company that provides the feature
+providerName=JBoss by Red Hat
+
+# "updateSiteName" property - label for the update site
+updateSiteName=JBossTools Update Site
+
+devUpdateSiteName=JBossTools Development Update Site
+
+# "description" property - description of the feature
+description=JBoss Tools Asciidoctor Preview for .adoc files
+
+copyright=Copyright (c) 2007-2014 Exadel, Inc and Red Hat, Inc.\n\
+Distributed under license by Red Hat, Inc. All rights reserved.\n\
+This program is made available under the terms of the\n\
+Eclipse Public License v1.0 which accompanies this distribution,\n\
+and is available at http\://www.eclipse.org/legal/epl-v10.html\n\
+Contributors\:\n\
+Exadel, Inc. and Red Hat, Inc. - initial API and implementation
+
+licenseURL=license.html
+updateSiteName=JBossTools Update Site
+
+# START NON-TRANSLATABLE
+# "license" property - text of the "Feature Update License"
+# should be plain text version of license agreement pointed to be "licenseURL"
+license=Red Hat, Inc. licenses these features and plugins to you under \
+certain open source licenses (or aggregations of such licenses), which \
+in a particular case may include the Eclipse Public License, the GNU \
+Lesser General Public License, and/or certain other open source \
+licenses. For precise licensing details, consult the corresponding \
+source code, or contact Red Hat Legal Affairs, 1801 Varsity Drive, \
+Raleigh NC 27606 USA.
+# END NON-TRANSLATABLE
+########### end of license property ##########################################

--- a/features/org.jboss.tools.asciidoctor.feature/feature.xml
+++ b/features/org.jboss.tools.asciidoctor.feature/feature.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.jboss.tools.asciidoctor.feature"
+      label="%featureName"
+      version="1.0.0.qualifier"
+      provider-name="%providerName">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="org.jboss.tools.asciidoctor.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/features/org.jboss.tools.asciidoctor.feature/license.html
+++ b/features/org.jboss.tools.asciidoctor.feature/license.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<html>
+
+<body>
+<p>Red Hat, Inc. licenses these features and plugins to you under
+certain open source licenses (or aggregations of such licenses), which
+in a particular case may include the Eclipse Public License, the GNU
+Lesser General Public License, and/or certain other open source
+licenses. For precise licensing details, consult the corresponding
+source code, or contact Red Hat Legal Affairs, 1801 Varsity Drive,
+Raleigh NC 27606 USA.
+</p>
+</body>
+</html>

--- a/features/org.jboss.tools.asciidoctor.feature/pom.xml
+++ b/features/org.jboss.tools.asciidoctor.feature/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion> 
+	<parent>
+		<groupId>org.jboss.tools.asciidoctor</groupId>
+		<artifactId>features</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<groupId>org.jboss.tools.asciidoctor.features</groupId>
+	<artifactId>org.jboss.tools.asciidoctor.feature</artifactId> 
+	<packaging>eclipse-feature</packaging>
+</project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<modelVersion>4.0.0</modelVersion>
+<parent>
+<groupId>org.jboss.tools</groupId>
+<artifactId>asciidoctor</artifactId>
+<version>1.0.0-SNAPSHOT</version>
+</parent>
+<groupId>org.jboss.tools.asciidoctor</groupId>
+<artifactId>features</artifactId>
+<name>asciidoctor.features</name>
+<packaging>pom</packaging>
+<modules>
+<module>org.jboss.tools.asciidoctor.feature</module>
+</modules>
+<build>
+<plugins>
+<plugin>
+<groupId>org.eclipse.tycho.extras</groupId>
+<artifactId>tycho-source-feature-plugin</artifactId>
+</plugin>
+<plugin>
+<groupId>org.eclipse.tycho</groupId>
+<artifactId>tycho-p2-plugin</artifactId>
+</plugin>
+</plugins>
+</build>
+</project>

--- a/plugins/org.jboss.tools.asciidoctor.ui/.classpath
+++ b/plugins/org.jboss.tools.asciidoctor.ui/.classpath
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/jruby-complete-1.7.3.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/asciidoctor-java-integration-0.1.2.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry exported="true" kind="lib" path="lib/asciidoctor-java-integration-0.1.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jruby-complete-1.7.3.jar"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.jboss.tools.asciidoctor.ui/.project
+++ b/plugins/org.jboss.tools.asciidoctor.ui/.project
@@ -20,8 +20,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/pom.xml
+++ b/pom.xml
@@ -3,18 +3,21 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0.Final-SNAPSHOT</version>
+		<version>4.3.0.Alpha1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>asciidoctor</artifactId>
-	<name>asciidoctor.all</name>
+	<name>jbosstools-asciidoctor</name>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
+	<properties>
+		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-jst.git</tycho.scmUrl>
+	</properties>
 	<modules>
 		<module>plugins</module>
-		<!--<module>tests</module>
+		<!--module>tests</module-->
 		<module>features</module>
-		<module>site</module>-->
+		<module>site</module>
 	</modules>
 </project>
 	

--- a/site/.project
+++ b/site/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>site</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/site/category.xml
+++ b/site/category.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+	<description>To install these features, point Eclipse at this site.</description>
+	<!-- JBoss Tools asciidoctor Nightly Build Update Site -->
+	<category-def label="JBoss Tools asciidoctor Nightly Build Update Site" name="JBoss Tools asciidoctor Nightly Build Update Site">
+		<description>JBoss Tools asciidoctor Nightly Build Update Site: contains all features in this build.</description>
+	</category-def>
+	<feature url="features/org.jboss.tools.asciidoctor.feature_0.0.0.jar" id="org.jboss.tools.asciidoctor.feature" version="0.0.0">
+		<category name="JBoss Tools asciidoctor Nightly Build Update Site"/>
+	</feature>
+	<!-- Sources -->
+	<feature url="features/org.jboss.tools.asciidoctor.feature.source_0.0.0.jar" id="org.jboss.tools.asciidoctor.feature.source" version="0.0.0">
+		<category name="JBoss Tools asciidoctor Nightly Build Update Site"/>
+	</feature>
+</site>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion> 
+	<parent>
+		<groupId>org.jboss.tools</groupId>
+		<version>1.0.0-SNAPSHOT</version>
+		<artifactId>asciidoctor</artifactId>
+	</parent>
+	<groupId>org.jboss.tools.asciidoctor</groupId>
+	<artifactId>asciidoctor.site</artifactId> 
+	<name>asciidoctor.site</name>
+	
+	<packaging>eclipse-repository</packaging>
+</project>


### PR DESCRIPTION
Fix contains:
- update to latest jbosstools-build/parent/pom.xml
- feature to aggregate plug-ins
- update site to install asciidoctor preview
